### PR TITLE
Implement plain string in QrHandler

### DIFF
--- a/src/main/java/it/auties/whatsapp/api/QrHandler.java
+++ b/src/main/java/it/auties/whatsapp/api/QrHandler.java
@@ -46,6 +46,17 @@ public non-sealed interface QrHandler extends Consumer<String>, WebVerificationS
     }
 
     /**
+     * Transforms the qr code in a UTF-8 plain string and accepts a consumer for the latter
+     *
+     * @param smallQrConsumer the non-null consumer
+     */
+    static QrHandler toPlainString(Consumer<String> qrConsumer) {
+        return qr -> {
+            qrConsumer.accept(qr);
+        };
+    }
+
+    /**
      * Utility method to create a matrix from a qr countryCode
      *
      * @param qr     the non-null source

--- a/src/main/java/it/auties/whatsapp/api/QrHandler.java
+++ b/src/main/java/it/auties/whatsapp/api/QrHandler.java
@@ -48,7 +48,7 @@ public non-sealed interface QrHandler extends Consumer<String>, WebVerificationS
     /**
      * Transforms the qr code in a UTF-8 plain string and accepts a consumer for the latter
      *
-     * @param smallQrConsumer the non-null consumer
+     * @param qrConsumer the non-null consumer
      */
     static QrHandler toPlainString(Consumer<String> qrConsumer) {
         return qr -> {


### PR DESCRIPTION
Problem described in [Issue 406](https://github.com/Auties00/Cobalt/issues/406). The solution is to make the consumer directly accept the QR plain string without converting it to an ASCII matrix.