### PR TITLE
Remove Early Return from onUpdateChatPresence

### DIFF
--- a/src/main/java/it/auties/whatsapp/socket/SocketHandler.java
+++ b/src/main/java/it/auties/whatsapp/socket/SocketHandler.java
@@ -662,10 +662,6 @@ public class SocketHandler implements SocketListener {
         var contact = store.findContactByJid(jid);
         if (contact.isPresent()) {
             contact.get().setLastKnownPresence(status);
-            if (status == contact.get().lastKnownPresence()) {
-                return;
-            }
-
             contact.get().setLastSeen(ZonedDateTime.now());
         }
 


### PR DESCRIPTION
Problem referred to in #414. I am unable to test this due to unadded files in the latest commit in the master branch (ChatMessageKeyBuilder for example).