### PR TITLE
Feat: handling edited messages + Fix: protocolType() exception

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
         <java.version>21</java.version>
         <maven.surefire.plugin.version>3.0.0-M9</maven.surefire.plugin.version>
         <maven.gpg.plugin.version>3.0.1</maven.gpg.plugin.version>
-        <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
+        <maven.compiler.plugin.version>3.11.0</maven.compiler.plugin.version>
         <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
         <maven.javadoc.plugin.version>3.5.0</maven.javadoc.plugin.version>
         <maven.nexus.plugin.version>1.6.13</maven.nexus.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
         <java.version>21</java.version>
         <maven.surefire.plugin.version>3.0.0-M9</maven.surefire.plugin.version>
         <maven.gpg.plugin.version>3.0.1</maven.gpg.plugin.version>
-        <maven.compiler.plugin.version>3.11.0</maven.compiler.plugin.version>
+        <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
         <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
         <maven.javadoc.plugin.version>3.5.0</maven.javadoc.plugin.version>
         <maven.nexus.plugin.version>1.6.13</maven.nexus.plugin.version>

--- a/src/main/java/it/auties/whatsapp/socket/MessageHandler.java
+++ b/src/main/java/it/auties/whatsapp/socket/MessageHandler.java
@@ -1076,10 +1076,12 @@ class MessageHandler {
             return;
         }
         if (info.message().hasCategory(MessageCategory.SERVER)) {
-            if (info.message().content() instanceof ProtocolMessage protocolMessage) {
+            if (!(info.message().content() instanceof ProtocolMessage protocolMessage)) return;
+            if (protocolMessage.protocolType() == null) return;
+            if (!protocolMessage.protocolType().equals(ProtocolMessage.Type.MESSAGE_EDIT)) {
                 handleProtocolMessage(info, protocolMessage);
+                return;
             }
-            return;
         }
 
         var chat = info.chat()


### PR DESCRIPTION
Sometimes, when a verified BOT send a message to the host, after a time, the session starts to throw an exception, here's the message:

[Message info.txt](https://github.com/Auties00/Cobalt/files/15046547/More.info.txt)

And here's the exception:

`java.lang.NullPointerException: Cannot invoke "it.auties.whatsapp.model.message.server.ProtocolMessage$Type.ordinal()" because the return value of "it.auties.whatsapp.model.message.server.ProtocolMessage.protocolType()" is null
	at it.auties.whatsapp.socket.MessageHandler.handleProtocolMessage(MessageHandler.java:934)
	at it.auties.whatsapp.socket.MessageHandler.saveMessage(MessageHandler.java:901)
	at it.auties.whatsapp.socket.MessageHandler.decodeChatMessage(MessageHandler.java:806)
	at it.auties.whatsapp.socket.MessageHandler.lambda$decode$55(MessageHandler.java:618)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at it.auties.whatsapp.socket.MessageHandler.decode(MessageHandler.java:618)
	at it.auties.whatsapp.socket.SocketHandler.decodeMessage(SocketHandler.java:447)
	at it.auties.whatsapp.socket.StreamHandler.digest(StreamHandler.java:107)
	at it.auties.whatsapp.socket.SocketHandler.onMessage(SocketHandler.java:201)
	at it.auties.whatsapp.socket.SocketSession$WebSocketSession.notifyMessage(SocketSession.java:150)
	at it.auties.whatsapp.socket.SocketSession$WebSocketSession.onBinary(SocketSession.java:139)
	at it.auties.whatsapp.socket.SocketSession$WebSocketSession.onBinary(SocketSession.java:141)
	at it.auties.whatsapp.socket.SocketSession$WebSocketSession.onBinary(SocketSession.java:141)
`