### PR TITLE
Quoted message overriding contextInfo

### DIFF
--- a/src/main/java/it/auties/whatsapp/api/Whatsapp.java
+++ b/src/main/java/it/auties/whatsapp/api/Whatsapp.java
@@ -503,8 +503,7 @@ public class Whatsapp {
      * @return a CompletableFuture
      */
     public CompletableFuture<? extends MessageInfo> sendMessage(JidProvider chat, ContextualMessage<?> message, MessageInfo quotedMessage) {
-        var contextInfo = ContextInfo.of(quotedMessage);
-        message.setContextInfo(contextInfo);
+        message.contextInfo().ifPresentOrElse(contextInfo -> message.setContextInfo(ContextInfo.of(contextInfo, quotedMessage)), () -> message.setContextInfo(ContextInfo.of(quotedMessage)));
         return sendMessage(chat, MessageContainer.of(message));
     }
 
@@ -517,8 +516,7 @@ public class Whatsapp {
      * @return a CompletableFuture
      */
     public CompletableFuture<ChatMessageInfo> sendChatMessage(JidProvider chat, ContextualMessage<?> message, MessageInfo quotedMessage) {
-        var contextInfo = ContextInfo.of(quotedMessage);
-        message.setContextInfo(contextInfo);
+        message.contextInfo().ifPresentOrElse(contextInfo -> message.setContextInfo(ContextInfo.of(contextInfo, quotedMessage)), () -> message.setContextInfo(ContextInfo.of(quotedMessage)));
         return sendChatMessage(chat, MessageContainer.of(message));
     }
 
@@ -532,8 +530,7 @@ public class Whatsapp {
      * @return a CompletableFuture
      */
     public CompletableFuture<NewsletterMessageInfo> sendNewsletterMessage(JidProvider chat, ContextualMessage<?> message, MessageInfo quotedMessage) {
-        var contextInfo = ContextInfo.of(quotedMessage);
-        message.setContextInfo(contextInfo);
+        message.contextInfo().ifPresentOrElse(contextInfo -> message.setContextInfo(ContextInfo.of(contextInfo, quotedMessage)), () -> message.setContextInfo(ContextInfo.of(quotedMessage)));
         return sendNewsletterMessage(chat, MessageContainer.of(message));
     }
 

--- a/src/main/java/it/auties/whatsapp/api/Whatsapp.java
+++ b/src/main/java/it/auties/whatsapp/api/Whatsapp.java
@@ -583,7 +583,7 @@ public class Whatsapp {
                 .status(MessageStatus.PENDING)
                 .senderJid(jidOrThrowError())
                 .key(key)
-                .message(message.withDeviceInfo(deviceInfo))
+                .message(recipient.toJid().hasServer(JidServer.GROUP) ? message : message.withDeviceInfo(deviceInfo))
                 .timestampSeconds(timestamp)
                 .broadcast(recipient.toJid().hasServer(JidServer.BROADCAST))
                 .build();

--- a/src/main/java/it/auties/whatsapp/model/info/ContextInfo.java
+++ b/src/main/java/it/auties/whatsapp/model/info/ContextInfo.java
@@ -226,6 +226,37 @@ public final class ContextInfo implements Info, ProtobufMessage {
                 .build();
     }
 
+    public static ContextInfo of(ContextInfo context, MessageInfo quotedMessage) {
+        return new ContextInfoBuilder()
+                .quotedMessageId(quotedMessage.id())
+                .quotedMessage(quotedMessage.message())
+                .quotedMessageChatJid(quotedMessage.parentJid())
+                .quotedMessageSenderJid(quotedMessage.senderJid())
+                .actionLink(context.actionLink().orElse(null))
+                .conversionData(context.conversionData().orElse(null))
+                .conversionSource(context.conversionSource().orElse(null))
+                .conversionDelaySeconds(context.conversionDelaySeconds())
+                .entryPointConversionApp(context.entryPointConversionApp().orElse(null))
+                .entryPointConversionSource(context.entryPointConversionSource().orElse(null))
+                .entryPointConversionDelaySeconds(context.entryPointConversionDelaySeconds())
+                .disappearingMode(context.disappearingMode().orElse(null))
+                .ephemeralExpiration(context.ephemeralExpiration())
+                .ephemeralSettingTimestamp(context.ephemeralSettingTimestamp())
+                .externalAdReply(context.externalAdReply().orElse(null))
+                .forwarded(context.forwarded())
+                .forwardingScore(context.forwardingScore())
+                .groupSubject(context.groupSubject().orElse(null))
+                .ephemeralSharedSecret(context.ephemeralSharedSecret().orElse(null))
+                .parentGroup(context.parentGroup().orElse(null))
+                .placeholderKey(context.placeholderKey().orElse(null))
+                .quotedAd(context.quotedAd().orElse(null))
+                .trustBannerAction(context.trustBannerAction())
+                .trustBannerType(context.trustBannerType().orElse(null))
+                .mentions(context.mentions())
+                .build();
+    }
+
+
     public static ContextInfo empty() {
         return new ContextInfoBuilder()
                 .mentions(new ArrayList<>())

--- a/src/main/java/it/auties/whatsapp/socket/MessageHandler.java
+++ b/src/main/java/it/auties/whatsapp/socket/MessageHandler.java
@@ -1076,10 +1076,12 @@ class MessageHandler {
             return;
         }
         if (info.message().hasCategory(MessageCategory.SERVER)) {
-            if (info.message().content() instanceof ProtocolMessage protocolMessage) {
+            if (!(info.message().content() instanceof ProtocolMessage protocolMessage)) return;
+            if (protocolMessage.protocolType() == null) return;
+            if (!protocolMessage.protocolType().equals(ProtocolMessage.Type.MESSAGE_EDIT)) {
                 handleProtocolMessage(info, protocolMessage);
+                return;
             }
-            return;
         }
 
         var chat = info.chat()

--- a/src/main/java/it/auties/whatsapp/socket/SocketHandler.java
+++ b/src/main/java/it/auties/whatsapp/socket/SocketHandler.java
@@ -721,9 +721,13 @@ public class SocketHandler implements SocketListener {
                 .put("t", Clock.nowMilliseconds(), () -> Objects.equals(type, "read") || Objects.equals(type, "read-self"))
                 .put("to", jid)
                 .put("type", type, Objects::nonNull);
-        if (Objects.equals(type, "sender") && jid.hasServer(JidServer.WHATSAPP)) {
-            attributes.put("recipient", jid);
-            attributes.put("to", participant);
+        if (Objects.equals(type, "sender")) {
+            if (jid.hasServer(JidServer.WHATSAPP))  {
+                attributes.put("recipient", jid);
+                attributes.put("to", participant);
+            } else if (jid.hasServer(JidServer.GROUP)) {
+                attributes.put("participant", participant);
+            }
         }
 
         var receipt = Node.of("receipt", attributes.toMap(), toMessagesNode(messages));


### PR DESCRIPTION
When `sendMessage` is used with `quotedMessage` parameter, quoted overrides contextInfo present on original message
I don't know if this method is the best method to fix this, but thats the first way I thought 