### PR TITLE
Fix: quoted message overriding contextInfo

### DIFF
--- a/src/main/java/it/auties/whatsapp/api/Whatsapp.java
+++ b/src/main/java/it/auties/whatsapp/api/Whatsapp.java
@@ -503,8 +503,7 @@ public class Whatsapp {
      * @return a CompletableFuture
      */
     public CompletableFuture<? extends MessageInfo> sendMessage(JidProvider chat, ContextualMessage<?> message, MessageInfo quotedMessage) {
-        var contextInfo = ContextInfo.of(quotedMessage);
-        message.setContextInfo(contextInfo);
+        message.contextInfo().ifPresentOrElse(contextInfo -> message.setContextInfo(ContextInfo.of(contextInfo, quotedMessage)), () -> message.setContextInfo(ContextInfo.of(quotedMessage)));
         return sendMessage(chat, MessageContainer.of(message));
     }
 
@@ -517,8 +516,7 @@ public class Whatsapp {
      * @return a CompletableFuture
      */
     public CompletableFuture<ChatMessageInfo> sendChatMessage(JidProvider chat, ContextualMessage<?> message, MessageInfo quotedMessage) {
-        var contextInfo = ContextInfo.of(quotedMessage);
-        message.setContextInfo(contextInfo);
+        message.contextInfo().ifPresentOrElse(contextInfo -> message.setContextInfo(ContextInfo.of(contextInfo, quotedMessage)), () -> message.setContextInfo(ContextInfo.of(quotedMessage)));
         return sendChatMessage(chat, MessageContainer.of(message));
     }
 
@@ -532,8 +530,7 @@ public class Whatsapp {
      * @return a CompletableFuture
      */
     public CompletableFuture<NewsletterMessageInfo> sendNewsletterMessage(JidProvider chat, ContextualMessage<?> message, MessageInfo quotedMessage) {
-        var contextInfo = ContextInfo.of(quotedMessage);
-        message.setContextInfo(contextInfo);
+        message.contextInfo().ifPresentOrElse(contextInfo -> message.setContextInfo(ContextInfo.of(contextInfo, quotedMessage)), () -> message.setContextInfo(ContextInfo.of(quotedMessage)));
         return sendNewsletterMessage(chat, MessageContainer.of(message));
     }
 

--- a/src/main/java/it/auties/whatsapp/model/info/ContextInfo.java
+++ b/src/main/java/it/auties/whatsapp/model/info/ContextInfo.java
@@ -226,6 +226,36 @@ public final class ContextInfo implements Info, ProtobufMessage {
                 .build();
     }
 
+    public static ContextInfo of(ContextInfo contextInfo, MessageInfo quotedMessage) {
+        return new ContextInfoBuilder()
+                .quotedMessageId(quotedMessage.id())
+                .quotedMessage(quotedMessage.message())
+                .quotedMessageChatJid(quotedMessage.parentJid())
+                .quotedMessageSenderJid(quotedMessage.senderJid())
+                .actionLink(contextInfo.actionLink().orElse(null))
+                .conversionData(contextInfo.conversionData().orElse(null))
+                .conversionSource(contextInfo.conversionSource().orElse(null))
+                .conversionDelaySeconds(contextInfo.conversionDelaySeconds())
+                .entryPointConversionApp(contextInfo.entryPointConversionApp().orElse(null))
+                .entryPointConversionSource(contextInfo.entryPointConversionSource().orElse(null))
+                .entryPointConversionDelaySeconds(contextInfo.entryPointConversionDelaySeconds())
+                .disappearingMode(contextInfo.disappearingMode().orElse(null))
+                .ephemeralExpiration(contextInfo.ephemeralExpiration())
+                .ephemeralSettingTimestamp(contextInfo.ephemeralSettingTimestamp())
+                .externalAdReply(contextInfo.externalAdReply().orElse(null))
+                .forwarded(contextInfo.forwarded())
+                .forwardingScore(contextInfo.forwardingScore())
+                .groupSubject(contextInfo.groupSubject().orElse(null))
+                .ephemeralSharedSecret(contextInfo.ephemeralSharedSecret().orElse(null))
+                .parentGroup(contextInfo.parentGroup().orElse(null))
+                .placeholderKey(contextInfo.placeholderKey().orElse(null))
+                .quotedAd(contextInfo.quotedAd().orElse(null))
+                .trustBannerAction(contextInfo.trustBannerAction())
+                .trustBannerType(contextInfo.trustBannerType().orElse(null))
+                .mentions(contextInfo.mentions())
+                .build();
+    }
+
     public static ContextInfo empty() {
         return new ContextInfoBuilder()
                 .mentions(new ArrayList<>())

--- a/src/main/java/it/auties/whatsapp/model/info/ContextInfo.java
+++ b/src/main/java/it/auties/whatsapp/model/info/ContextInfo.java
@@ -227,33 +227,21 @@ public final class ContextInfo implements Info, ProtobufMessage {
     }
 
     public static ContextInfo of(ContextInfo contextInfo, MessageInfo quotedMessage) {
-        return new ContextInfoBuilder()
-                .quotedMessageId(quotedMessage.id())
-                .quotedMessage(quotedMessage.message())
-                .quotedMessageChatJid(quotedMessage.parentJid())
-                .quotedMessageSenderJid(quotedMessage.senderJid())
-                .actionLink(contextInfo.actionLink().orElse(null))
-                .conversionData(contextInfo.conversionData().orElse(null))
-                .conversionSource(contextInfo.conversionSource().orElse(null))
-                .conversionDelaySeconds(contextInfo.conversionDelaySeconds())
-                .entryPointConversionApp(contextInfo.entryPointConversionApp().orElse(null))
-                .entryPointConversionSource(contextInfo.entryPointConversionSource().orElse(null))
-                .entryPointConversionDelaySeconds(contextInfo.entryPointConversionDelaySeconds())
-                .disappearingMode(contextInfo.disappearingMode().orElse(null))
-                .ephemeralExpiration(contextInfo.ephemeralExpiration())
-                .ephemeralSettingTimestamp(contextInfo.ephemeralSettingTimestamp())
-                .externalAdReply(contextInfo.externalAdReply().orElse(null))
-                .forwarded(contextInfo.forwarded())
-                .forwardingScore(contextInfo.forwardingScore())
-                .groupSubject(contextInfo.groupSubject().orElse(null))
-                .ephemeralSharedSecret(contextInfo.ephemeralSharedSecret().orElse(null))
-                .parentGroup(contextInfo.parentGroup().orElse(null))
-                .placeholderKey(contextInfo.placeholderKey().orElse(null))
-                .quotedAd(contextInfo.quotedAd().orElse(null))
-                .trustBannerAction(contextInfo.trustBannerAction())
-                .trustBannerType(contextInfo.trustBannerType().orElse(null))
-                .mentions(contextInfo.mentions())
-                .build();
+        var newContext = of(quotedMessage);
+        var fields = contextInfo.getClass().getFields();
+        try {
+            for (var field : fields) {
+                field.setAccessible(true);
+                var value = field.get(contextInfo);
+                if (value != null) {
+                    field.set(newContext, value);
+                }
+            }
+            return newContext;
+        } catch (IllegalAccessException e) {
+            System.err.println("Failed to merge context info");
+            return ContextInfo.of(quotedMessage);
+        }
     }
 
     public static ContextInfo empty() {


### PR DESCRIPTION
When sendMessage is used with quotedMessage parameter, quotes overrides contextInfo present on original message 

I don't know if it's the best method fix this, but was the first way I thought