### PR TITLE
Fix dead sessions

### DIFF
--- a/src/main/java/it/auties/whatsapp/model/jid/Jid.java
+++ b/src/main/java/it/auties/whatsapp/model/jid/Jid.java
@@ -17,7 +17,7 @@ public record Jid(String user, JidServer server, Integer device, Integer agent) 
      */
     public Jid(String user, JidServer server, Integer device, Integer agent) {
         this.user = user != null && user.startsWith("+") ? user.substring(1) : user;
-        this.server = server;
+        this.server = agent != null && agent == 1 ? JidServer.LID : server;
         this.device = device;
         this.agent = agent;
     }


### PR DESCRIPTION
Idk if it's the correct way to supprot lids, but I noticed that when agent is `1`, the JID is a LID