### PR TITLE
Feat: responding a ping request from the server

### DIFF
--- a/src/main/java/it/auties/whatsapp/socket/StreamHandler.java
+++ b/src/main/java/it/auties/whatsapp/socket/StreamHandler.java
@@ -1337,6 +1337,11 @@ class StreamHandler {
     }
 
     private void digestIq(Node node) {
+        if (node.attributes().hasValue("xmlns", "urn:xmpp:ping")) {
+            socketHandler.sendQueryWithNoResponse("result", null);
+            return;
+        }
+        
         var container = node.findNode().orElse(null);
         if (container == null) {
             return;


### PR DESCRIPTION
Server sometimes send a ping request to the client, and we need to sent `result` to this